### PR TITLE
Revise planned changes for CI Workflows v4.0

### DIFF
--- a/docs/planned-changes/v4.md
+++ b/docs/planned-changes/v4.md
@@ -4,10 +4,11 @@ title: Version 4
 
 # Planned Changes for CI Workflows v4.0
 
-Currently, there are no planned changes for CI Workflows v4.0.
+::warning[Notice]
 
-When breaking changes or significant modifications are planned for the next major version, they will be documented here to provide advance notice to teams using these
-workflows.
+Encore Digital Group has moved from GitHub to GitLab. Open source workflows and actions will continue to be maintained, but are unlikely to receive new features unless our open-source packages require them in the GitHub mirror. 
+
+:::
 
 ## Future Planning
 


### PR DESCRIPTION
Updated the planned changes document to reflect the move from GitHub to GitLab and the maintenance status of open source workflows.